### PR TITLE
Add primary key to association table spec

### DIFF
--- a/src/csvw/db.py
+++ b/src/csvw/db.py
@@ -234,6 +234,9 @@ class TableSpec(object):
             foreign_keys=[
                 ([afk.name], atable, [apk]),
                 ([bfk.name], btable, [bpk]),
+            ],
+            primary_key=[
+                afk.name, bfk.name
             ]
         )
 


### PR DESCRIPTION
The occasion I did this was that I wanted to use SQLAlchemy's automap features
with some CLDF database objects. I hope this will also my colleague who wants
faster lookup of objects across association tables, because a primary key is
necessarily indexed.

I worry that I don't understand the logics of `context` outside CLDF
XXX_SourceTable tables well enough to be sure that this will always be a valid
primary key (as opposed to being only unique if `context` is included). I'll open a separate issue to ask about `context`: #38