### PR TITLE
support py3.10

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ $ pip install csvw
 - Low level CSV parsing is delegated to the `csv` module in Python's standard library. Thus, if a `commentPrefix`
   is specified in a `Dialect` instance, this will lead to skipping rows where the first value starts
   with `commentPrefix`, even if the value was quoted.
-  Also, cell content containing `escapechar` may not be round-tripped as expected,
+  Also, cell content containing `escapechar` may not be round-tripped as expected (when specifying
+- `escapechar` or a `csvw.Dialect` with `quoteChar` but `doubleQuote==False`),
   when minimal quoting is specified. This is due to inconsistent `csv` behaviour
   across Python versions (see https://bugs.python.org/issue44861).
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ $ pip install csvw
 - Low level CSV parsing is delegated to the `csv` module in Python's standard library. Thus, if a `commentPrefix`
   is specified in a `Dialect` instance, this will lead to skipping rows where the first value starts
   with `commentPrefix`, even if the value was quoted.
+  Also, cell content containing `escapechar` may not be round-tripped as expected,
+  when minimal quoting is specified. This is due to inconsistent `csv` behaviour
+  across Python versions (see https://bugs.python.org/issue44861).
 
 
 ### Deviations from the CSVW specificaton

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,6 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/tests/test_csv_escapechar.py
+++ b/tests/test_csv_escapechar.py
@@ -2,6 +2,7 @@
 
 import io
 import csv
+import sys
 
 import pytest
 
@@ -63,6 +64,7 @@ def test_escapecharquotechar(dialect):
     assert cell == value
 
 
+@pytest.mark.xfail(sys.version_info >= (3, 10), reason="https://bugs.python.org/issue44861")
 def test_escapequote_escapecharquotechar_final(dialect=EscapeQuote):
     value = 'spam %s%s' % (dialect.escapechar, dialect.quotechar)
     out, cell = roundtrip(value, dialect)

--- a/tests/test_dsv.py
+++ b/tests/test_dsv.py
@@ -1,5 +1,6 @@
 import io
 import csv
+import sys
 import shutil
 import pathlib
 from collections import OrderedDict
@@ -72,6 +73,7 @@ def test_UnicodeWriter(tmp_path, row, expected):
     assert filepath.read_bytes() == expected
 
 
+@pytest.mark.xfail(sys.version_info >= (3, 10), reason="https://bugs.python.org/issue44861")
 @pytest.mark.parametrize('quoting', [getattr(csv, q) for q in QUOTING], ids=QUOTING)
 def test_roundtrip_escapechar(tmp_path, quoting, escapechar='\\', row=['\\spam', 'eggs']):
     filename = tmp_path / 'spam.csv'

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,4 +1,5 @@
 import io
+import sys
 import json
 import shutil
 import decimal
@@ -59,6 +60,7 @@ class TestDialect(object):
         t.write(items, fname=fpath)
         return fpath.read_text(encoding='utf-8'), list(t.iterdicts(fname=fpath))
 
+    @pytest.mark.xfail(sys.version_info >= (3, 10), reason="https://bugs.python.org/issue44861")
     def test_doubleQuote(self, tmp_path):
         fpath = tmp_path / 'test'
         t = csvw.Table.fromvalue({

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39}
+envlist = py{36,37,38,39,310}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
So this PR simply accepts that we can't guarantee consistent roundtrip behaviour across all supported Python versions.

closes #58