### PR TITLE
update github actions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,11 +15,11 @@ jobs:
         python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -29,9 +29,9 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
-    - name: "Convert coverage"
-      run: "python -m coverage xml"
-    - name: "Upload coverage to Codecov"
-      uses: "codecov/codecov-action@v1"
+    - name: Convert coverage
+      run: python -m coverage xml
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/